### PR TITLE
Add filter for pickup address

### DIFF
--- a/includes/api/class-gls-shipping-api-data.php
+++ b/includes/api/class-gls-shipping-api-data.php
@@ -381,7 +381,7 @@ class GLS_Shipping_API_Data
             'ContactEmail' => get_option('admin_email')
         ];
 
-        return $pickup_address;
+        return apply_filters('gls_shipping_for_woocommerce_api_get_pickup_address', $pickup_address);
     }
 
     /**


### PR DESCRIPTION
Currently, there is no way to modify pickup address sent to the API which is displayed on the shipping label without modifying the source files (and losing these changes during update). I've made a simple change, so one could modify this data using a WordPress filter.